### PR TITLE
Patch 1

### DIFF
--- a/src/layouts/default.html.jade
+++ b/src/layouts/default.html.jade
@@ -34,7 +34,7 @@
 - scripts.add(["/vendor/jouele/jquery.jplayer.min.js","/vendor/jouele/jouele.js"])
 - styles.add(["/vendor/jouele/jouele.css"])
 
-:t(render="html")
+:t
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/src/layouts/post.html.jade
+++ b/src/layouts/post.html.jade
@@ -60,7 +60,7 @@ layout: default
 if document.comments
   .row
     .col-md-12
-      :t(render="html")
+      :t
         <div class="comment-section">
           <div id="disqus_thread"></div>
           <script type="text/javascript">


### PR DESCRIPTION
you had an error because you were trying to render html content into html which doesn't make sense. You can just use <t></t> if no rendering must be involved. I tried locally and after these 2 small changes no mo errors get on the console, and commenting with GA still works 
